### PR TITLE
Only restrict signature algorithms for signing key in samples

### DIFF
--- a/samples/standalone/client-openssl/client_sample.cpp
+++ b/samples/standalone/client-openssl/client_sample.cpp
@@ -8,7 +8,7 @@
 
 static CURLcode restrict_digest_function(CURL* curl, void* sslctx, void* parm) {
   SSL_CTX* ctx = (SSL_CTX*)sslctx;
-  SSL_CTX_set1_sigalgs_list(ctx, "RSA+SHA384");
+  SSL_CTX_set1_sigalgs_list(ctx, "RSA+SHA1:RSA+SHA256:RSA+SHA384");
 
   return CURLE_OK;
 }
@@ -43,7 +43,10 @@ int main(int argc, const char** argv) {
 
   curl = curl_easy_init();
 
-  curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, restrict_digest_function);
+  if (std::string(identifier) == "signing") {
+    // Signing key only supports a limited amount of signing algorithms
+    curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, restrict_digest_function);
+  }
 
   curl_easy_setopt(curl, CURLOPT_URL, url);
   if (curl_easy_setopt(curl, CURLOPT_SSLENGINE, "tob_mias") != CURLE_OK) {

--- a/samples/standalone/paho-openssl/linuxToB/MQTTLinuxToB.h
+++ b/samples/standalone/paho-openssl/linuxToB/MQTTLinuxToB.h
@@ -30,7 +30,7 @@ class ToBIPStack
 
     static CURLcode restrict_digest_function(CURL* curl, void* sslctx, void* parm) {
       SSL_CTX* ctx = (SSL_CTX*)sslctx;
-      SSL_CTX_set1_sigalgs_list(ctx, "RSA+SHA384");
+      SSL_CTX_set1_sigalgs_list(ctx, "RSA+SHA1:RSA+SHA256:RSA+SHA384");
 
       return CURLE_OK;
     }
@@ -44,7 +44,10 @@ class ToBIPStack
 
       curl = curl_easy_init();
 
-      curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, restrict_digest_function);
+      if (strcmp(tob_cert, "signing") == 0) {
+        // Signing key only supports a limited amount of signing algorithms
+        curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, restrict_digest_function);
+      }
 
       curl_easy_setopt(curl, CURLOPT_URL, url);
       if (curl_easy_setopt(curl, CURLOPT_SSLENGINE, "tob_mias") != CURLE_OK) {
@@ -135,6 +138,7 @@ class ToBIPStack
       curl_easy_cleanup(curl);
 
       std::cout << "Network disconnect called" << std::endl;
+      return 0;
     }
 
   private:


### PR DESCRIPTION
 * Available key can be used with TLSv1.3, no need to restrict
 * Also list all valid algorithms for the signing key
 * Also fix a warning for paho sample